### PR TITLE
Routing problem after remove cache

### DIFF
--- a/DisplayBundle/Manager/SiteManager.php
+++ b/DisplayBundle/Manager/SiteManager.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class SiteManager implements CurrentSiteIdInterface
 {
-    protected $siteId = '1';
+    protected $siteId = '0';
     protected $requestStack;
     protected $siteRepository;
 
@@ -27,7 +27,11 @@ class SiteManager implements CurrentSiteIdInterface
         $request = $this->requestStack->getCurrentRequest();
 
         if (!is_null($request)) {
-            $this->siteId = $request->server->get('SYMFONY__SITE');
+            $siteId = $request->server->get('SYMFONY__SITE');
+            $site = $this->siteRepository->findOneBySiteIdNotDeleted($siteId);
+            if ($site) {
+                $this->siteId = $request->server->get('SYMFONY__SITE');
+            }
         }
     }
 


### PR DESCRIPTION
Cette PR ne solutionne pas le problème initial mais amène des ajustements sur deux anomalies levées lors de l'investigation. Le problème est provoqué par la construction du service siteManager qui n'est pas faite correctement car la request stack est vide quand le cache l'est également. Après génération du cache (ie un F5) la requeststack est correcte et tout se passe normalement.
Un app/console clear:cache ne génère donc pas le bug grâce au warmup qu'il comprend, un rm -Rf cache lui par contre provoque le bug.

Les points corrigés à côté sont les suivants :
1/ on ne testait pas si le site qu'on déclarait comme courant était toujours disponible ou était 'deleted'
2/ le currentSIte recevait par défaut la valeur 1, ce qui explique l'affichage par défaut du premier site des fixtures quand la requeststack est vide et qu'on ne set donc pas le siteId. La valeur est passée par défaut à 0 maintenant ce qui lève  une 404 nonexistingdocument.
