### PR TITLE
Move getCacheTags from abstractStrategy to strategies

### DIFF
--- a/DisplayBundle/DisplayBlock/Strategies/AbstractStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/AbstractStrategy.php
@@ -54,10 +54,7 @@ abstract class AbstractStrategy implements DisplayBlockInterface
      * 
      * @return Array
      */
-    public function getCacheTags(ReadBlockInterface $block)
-    {
-        return array();
-    }
+    abstract public function getCacheTags(ReadBlockInterface $block);
 
     /**
      * Renders a view.

--- a/DisplayBundle/DisplayBlock/Strategies/AddThisStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/AddThisStrategy.php
@@ -44,6 +44,16 @@ class AddThisStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/AudienceAnalysisStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/AudienceAnalysisStrategy.php
@@ -66,6 +66,16 @@ class AudienceAnalysisStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/ContactStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/ContactStrategy.php
@@ -110,6 +110,16 @@ class ContactStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/GmapStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/GmapStrategy.php
@@ -57,6 +57,16 @@ class GmapStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/LanguageListStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/LanguageListStrategy.php
@@ -105,6 +105,16 @@ class LanguageListStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/SampleStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/SampleStrategy.php
@@ -51,6 +51,16 @@ class SampleStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/TinyMCEWysiwygStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/TinyMCEWysiwygStrategy.php
@@ -71,6 +71,16 @@ class TinyMCEWysiwygStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/DisplayBundle/DisplayBlock/Strategies/VideoStrategy.php
+++ b/DisplayBundle/DisplayBlock/Strategies/VideoStrategy.php
@@ -192,6 +192,16 @@ class VideoStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     * 
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string


### PR DESCRIPTION
[OO-BCBREAK] DisplayBundle/DisplayBlock/Strategies/AbstractStrategy:getCacheTags() is now abstract and must therefore be explicitally implemented on each display strategy
https://github.com/open-orchestra/open-orchestra-display-bundle/pull/200
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/166
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/17